### PR TITLE
Upstream Our Networks edits

### DIFF
--- a/terraform/shared/video-player/css/common.css
+++ b/terraform/shared/video-player/css/common.css
@@ -19,6 +19,11 @@ h2 {
   font-weight: normal;
 }
 
+p {
+  margin-top: 0;
+  margin-bottom: 1em;
+}
+
 /* Live Stream Container */
 
 .stream-container {
@@ -40,12 +45,19 @@ h2 {
   background: #ffffff;
   left: 0;
   text-align: center;
+  z-index: 10;
 }
 
 .stream-selector-options {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.stream-option-wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
 }
 
 .stream-option {
@@ -98,6 +110,36 @@ h2 {
   margin: 0 auto;
   max-width: 75%;
   font-size: 0.85em;
+}
+
+.stream-option-title-helper {
+  position: absolute;
+  top: 100%;
+  display: none;
+  width: 225px;
+  font-size: 0.85em;
+  line-height: 1.2em;
+  color: #777;
+  white-space: normal;
+}
+
+.stream-option-wrapper:hover .stream-option-title-helper {
+  display: block;
+}
+
+.stream-refresh {
+  cursor: pointer;
+  margin-top: 1em;
+  background: #000000;
+  border-color: #000000;
+  color: #ffffff;
+  font-size: 0.85em;
+  padding: 15px 20px;
+}
+
+.stream-refresh:hover {
+  background-color: #333;
+  border-color: #333;
 }
 
 .button-label {

--- a/terraform/shared/video-player/index.html
+++ b/terraform/shared/video-player/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>IPFS Live Streaming</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,17 +16,23 @@
         <div id="SelectStream">
           <h2>Select Live Stream Source</h2>
           <div class="stream-selector-options">
-            <div id="ipfsStream">
-              <button class="stream-option ipfs-stream" title="Play the live stream on through a peer-to-peer hypermedia protocol. More at ipfs.io">
+            <div class="stream-option-wrapper" id="ipfsStream">
+              <button class="stream-option ipfs-stream">
                 <img class="stream-option-graphic" src="graphics/ipfs-icon.svg" alt="IPFS graphic" />
                 <span class="button-label">IPFS</span>
               </button>
+              <div class="stream-option-title-helper">
+                <p>Play the live stream on through a peer-to-peer hypermedia protocol. More at <a href="https://ipfs.io" target="_blank">ipfs.io</a></p>
+              </div>
             </div>
-            <div id="httpStream">
-              <button class="stream-option http-stream" title="Play the live stream on through a media server over HTTP.">
+            <div class="stream-option-wrapper" id="httpStream">
+              <button class="stream-option http-stream">
                 <img class="stream-option-graphic" src="graphics/http-icon.svg" alt="Media server graphic" />
                 <span class="button-label">HTTP</span>
               </button>
+              <div class="stream-option-title-helper">
+                <p>Play the live stream on through a media server over HTTP</p>
+              </div>
             </div>
           </div>
         </div>

--- a/terraform/shared/video-player/js/common.js
+++ b/terraform/shared/video-player/js/common.js
@@ -1,11 +1,10 @@
 // JavaScript Document
 
-var domain = 'ipfs01.vz.jgndata.biz';
-var ipfs_gateway_self = 'http://' + domain + ':8080'; // IPFS gateway of this node
-var ipfs_gateway_origin = 'http://ipfs-server.mesh.world:8080'; // IPFS gateway of origin stream
-var m3u8_ipfs = 'http://' + domain + '/live.m3u8'; // File path to m3u8 with IPFS content via HTTP server
-// var m3u8_ipfs = '/ipns/__IPFS_ID_ORIGIN__'; // URL to m3u8 via IPNS (uncomment to enable)
-var m3u8_http_urls = ['https://stream.aseriesoftubez.com/hls/tomesh/ournetworks.m3u8']; // Optional list of URLs to m3u8 over HTTP
+var ipfs_gateway_self = '__IPFS_GATEWAY_SELF__'; // IPFS gateway of this node
+var ipfs_gateway_origin = '__IPFS_GATEWAY_ORIGIN__'; // IPFS gateway of origin stream
+var m3u8_ipfs = 'live.m3u8'; // File path to m3u8 with IPFS content via HTTP server
+// var m3u8_ipfs = '__IPFS_GATEWAY_ORIGIN__/ipns/__IPFS_ID_ORIGIN__'; // URL to m3u8 via IPNS (uncomment to enable)
+var m3u8_http_urls = [__M3U8_HTTP_URLS__]; // Optional list of URLs to m3u8 over HTTP
 
 function getQueryVariable(variable) {
   var query = window.location.search.substring(1);

--- a/terraform/shared/video-player/js/common.js
+++ b/terraform/shared/video-player/js/common.js
@@ -1,34 +1,36 @@
 // JavaScript Document
-var ipfs_gateway_self='__IPFS_GATEWAY_SELF__';  // IPFS gateway of this node
-var ipfs_gateway_origin='__IPFS_GATEWAY_ORIGIN__';  // IPFS gateway of origin stream
-var m3u8_ipfs='live.m3u8';  // File path to m3u8 with IPFS content via HTTP server
-// var m3u8_ipfs='__IPFS_GATEWAY_ORIGIN__/ipns/__IPFS_ID_ORIGIN__';  // URL to m3u8 via IPNS (uncomment to enable)
-var m3u8_http_urls=[__M3U8_HTTP_URLS__];  // Optional list of URLs to m3u8 over HTTP
+
+var domain = 'ipfs01.vz.jgndata.biz';
+var ipfs_gateway_self = 'http://' + domain + ':8080'; // IPFS gateway of this node
+var ipfs_gateway_origin = 'http://ipfs-server.mesh.world:8080'; // IPFS gateway of origin stream
+var m3u8_ipfs = 'http://' + domain + '/live.m3u8'; // File path to m3u8 with IPFS content via HTTP server
+// var m3u8_ipfs = '/ipns/__IPFS_ID_ORIGIN__'; // URL to m3u8 via IPNS (uncomment to enable)
+var m3u8_http_urls = ['https://stream.aseriesoftubez.com/hls/tomesh/ournetworks.m3u8']; // Optional list of URLs to m3u8 over HTTP
 
 function getQueryVariable(variable) {
   var query = window.location.search.substring(1);
   var vars = query.split('&');
   for (var i = 0; i < vars.length; i++) {
     var pair = vars[i].split('=');
-    if (decodeURIComponent(pair[0]) == variable) {
+    if (decodeURIComponent(pair[0]) === variable) {
       return decodeURIComponent(pair[1]);
     }
   }
   console.log('Query variable %s not found', variable);
 }
 
-if (getQueryVariable("url")) {
-  m3u8_ipfs = getQueryVariable("url");
+if (getQueryVariable('url')) {
+  m3u8_ipfs = getQueryVariable('url');
 }
 
-if (getQueryVariable("ipfs_gateway_self")) {
-  ipfs_gateway_self = getQueryVariable("ipfs_gateway_self");
+if (getQueryVariable('ipfs_gateway_self')) {
+  ipfs_gateway_self = getQueryVariable('ipfs_gateway_self');
 }
 
 var live = videojs('live');
 
 // For any browser except Safari
-if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent) == false) {
+if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent) === false) {
   // Override native player for platform and browser consistency
   videojs.options.html5.nativeAudioTracks = false;
   videojs.options.html5.nativeVideoTracks = false;
@@ -38,7 +40,7 @@ if (/^((?!chrome|android).)*safari/i.test(navigator.userAgent) == false) {
 function httpStream() {
   live.src({
     src: m3u8_http_urls[Math.floor(Math.random() * m3u8_http_urls.length)],
-    type: 'application/x-mpegURL',
+    type: 'application/x-mpegURL'
   });
   loadStream();
 }
@@ -46,15 +48,15 @@ function httpStream() {
 function ipfsStream() {
   live.src({
     src: m3u8_ipfs,
-    type: 'application/x-mpegURL',
+    type: 'application/x-mpegURL'
   });
   loadStream();
   videojs.Hls.xhr.beforeRequest = function(options) {
     // Replace IPFS gateway of origin with that of this node
     options.uri = options.uri.replace(ipfs_gateway_origin, ipfs_gateway_self);
-    if (options.uri.indexOf("/ipfs/")) {
-      document.getElementById("loadingTitle").innerHTML = "Located stream via IPFS"
-      document.getElementById("msg").innerHTML = "Downloading video content..."
+    if (options.uri.indexOf('/ipfs/')) {
+      document.getElementById('loadingTitle').innerHTML = 'Located stream via IPFS';
+      document.getElementById('msg').innerHTML = 'Downloading video content...';
     }
     console.debug(options.uri);
     return options;
@@ -62,35 +64,43 @@ function ipfsStream() {
 }
 
 function loadStream() {
-  document.getElementById("LoadingStream").style.display = "block";
-  document.getElementById("SelectStream").style.display = "none";
+  document.getElementById('LoadingStream').style.display = 'block';
+  document.getElementById('SelectStream').style.display = 'none';
 }
 
-document.querySelector('.ipfs-stream').addEventListener('click', function(event){
+document.querySelector('.ipfs-stream').addEventListener('click', function(event) {
   ipfsStream();
 });
 
-document.querySelector('.http-stream').addEventListener('click', function(event){
+document.querySelector('.http-stream').addEventListener('click', function(event) {
   httpStream();
 });
 
-live.metadata="none";
+live.metadata = 'none';
 
 live.on('loadedmetadata', function() {
-  document.getElementById("StreamSelector").style.display = "none";
+  document.getElementById('StreamSelector').style.display = 'none';
 });
 
 live.on('loadeddata', function(event) {
   console.debug(event);
 });
 
-live.on('error', function(event) {
-  console.debug(this.error());
-  document.getElementById('loadingTitle').innerHTML = 'Unable to load live stream'
-  document.querySelector('.loader-animation').style.display = 'none';
-  document.getElementById('msg').innerHTML = this.error().message;
+var refreshButton = document.createElement('button');
+refreshButton.className = 'button button-primary compact stream-refresh';
+refreshButton.innerHTML = 'Refresh Page and Try Again';
+refreshButton.addEventListener('click', function() {
+  window.location.reload(true);
 });
 
-if (!m3u8_http_urls || !Array.isArray(m3u8_http_urls) || (m3u8_http_urls.length == 0)) {
+live.on('error', function(event) {
+  console.debug(this.error());
+  document.getElementById('loadingTitle').innerHTML = 'Unable to load live stream';
+  document.querySelector('.loader-animation').style.display = 'none';
+  document.getElementById('msg').innerHTML = this.error().message;
+  document.getElementById('LoadingStream').appendChild(refreshButton);
+});
+
+if (!m3u8_http_urls || !Array.isArray(m3u8_http_urls) || (m3u8_http_urls.length === 0)) {
   document.querySelector('.http-stream').setAttribute('disabled', 'disabled');
 }


### PR DESCRIPTION
Closes #39

This doesn't include the change made to `live-stream-embed.html`. The cache busting timestamp strings should ideally be generated on deploy. Not super sure on how to do it here with terraform